### PR TITLE
Fix classpath in automatic discovery example

### DIFF
--- a/runtime-job-worker/README.md
+++ b/runtime-job-worker/README.md
@@ -75,7 +75,7 @@ Specifying optional values allow you to override `@OutboundConnector` provided c
 CONNECTOR_HTTPJSON_FUNCTION=io.camunda.connector.http.HttpJsonFunction
 CONNECTOR_HTTPJSON_TYPE=non-default-httpjson-task-type
 
-java -cp 'connector-runtime-job-worker-with-dependencies.jar;connector-http-json-with-dependencies.jar' \
+java -cp 'connector-runtime-job-worker-with-dependencies.jar:connector-http-json-with-dependencies.jar' \
     io.camunda.connector.runtime.jobworker.Main
 ```
 


### PR DESCRIPTION
The classpath in the automatic discovery example is broken - it should be a full colon rather than a semi-colon. This commit fixes that.

## Description

Change semicolon to full colon.
